### PR TITLE
Fix skillpoint calculation for skills in queue that are not completed yet

### DIFF
--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -27,7 +27,7 @@ namespace EVEMon.Common.Models
             Level = serial.Level;
             Skill = character.Skills[serial.ID];
 
-            if (serial.IsTraining)
+            if (!serial.IsPaused)
             {
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;

--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -182,7 +182,7 @@ namespace EVEMon.Common.Models
             Items.Clear();
             foreach (SerializableQueuedSkill serialSkill in serial)
             {
-                if (!serialSkill.IsTraining)
+                if (serialSkill.IsPaused)
                     IsPaused = true;
 
                 // Creates the skill queue

--- a/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
+++ b/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
@@ -41,9 +41,21 @@ namespace EVEMon.Common.Serialization.Eve
         // When the skill queue is paused, startTime and endTime are empty in the XML document
         // As a result, the serialization leaves the DateTime with its default value
         [XmlIgnore]
+        public bool IsPaused
+        {
+            get { return EndTime == DateTime.MinValue; }
+        }
+
+        [XmlIgnore]
+        public bool IsCompleted
+        {
+            get { return !IsPaused && EndTime <= DateTime.UtcNow; }
+        }
+
+        [XmlIgnore]
         public bool IsTraining
         {
-            get { return EndTime != DateTime.MinValue; }
+            get { return !IsPaused && StartTime <= DateTime.UtcNow && DateTime.UtcNow <= EndTime; }
         }
 
         #region ISynchronizableWithLocalClock Members


### PR DESCRIPTION
Skills in the queue that were not yet begun would cause them to have their SP trained bumped up to the second-highest planned level, even though no levels had completed.

See the discussion on pulls https://github.com/peterhaneve/evemon/pull/12 and https://github.com/peterhaneve/evemon/pull/18 for details.